### PR TITLE
Use German words in better context

### DIFF
--- a/story.txt
+++ b/story.txt
@@ -4,9 +4,9 @@ When all of a sudden, a Porsche flew over head!
 A hund wearing a dirndel ran after it, barking and howling.
 The hund stumbled into a Biergartan.
 Fed up with this chaos, she got into her BMW and played some musik.
-However, the hund was a diehard Rammstein fan, and immediately bolted after Mehlhase as if she was driving a brot.
+However, the hund was a diehard Rammstein fan, and immediately bolted after Mehlhase with some brot in its mouth.
 She was chased all the way to Munich before the hund was distracted by some gebaeck.
 But then suddenly, Gauss appeared out of nowhere, high off his wettbewerbsfaehig!
 With a swing of his lederhosen and a dash to the left, he bashed the hund in a manner so swift!
 Not believing what he had done to the poor hund, he went to the local biergarten to cope.
-Mehlhase was finally safe, she was able to go back to admiring the beauty of Germany, even far enough to unlock the schloss
+Mehlhase was finally safe, she was able to go back to admiring the beauty of Germany, basking in the comfort of her klimaanlage.


### PR DESCRIPTION
Driving "bread" doesn't make much sense, and a discussion of unlocking a "padlock" right after admiring German landscapes sounds out of context.

This commit helps these sentences make more sense given the translations of the German words.